### PR TITLE
Single-user pulls

### DIFF
--- a/app/ClanCollector.py
+++ b/app/ClanCollector.py
@@ -20,6 +20,13 @@ class ClanCollector:
 
         self.members = None
 
+
+    def generateClanFolders(self):
+        # set up results directories
+        LocalController.CreateDirectoriesForClan(self.displayName)
+        LocalController.ClearResultDirectory(self.displayName)
+        LocalController.CreateDirectoriesForClan(self.displayName)
+
     
     def update(self, freshPull):
         if freshPull:
@@ -34,8 +41,9 @@ class ClanCollector:
             print(f"> Get clan profile from cache")
             self.RestoreClanFromCache()
             print(f"Restored clan from cache")
+        self.generateClanFolders()
         return self
-
+    
 
     def SaveClanToCache(self):
         # saves the clan id, name, and member list to a cache file
@@ -97,9 +105,10 @@ class ClanCollector:
 				'bungieGlobalDisplayName': profileJson['bungieGlobalDisplayName'],
 				'bungieGlobalDisplayNameCode': profileJson['bungieGlobalDisplayNameCode']
             }}]
-        a = True
-        # /Platform/Destiny2/3/Profile/4611686018472661350/?components=100
-    
+        # adding just one member means this is a single user pull, change clan name to reflect that and reset destination folder
+        self.displayName = f'{profileJson['bungieGlobalDisplayName']}[{profileJson['bungieGlobalDisplayNameCode']}]'
+        self.generateClanFolders()
+
 
     def getActivities(self, limit=None):
         print("> Get Activities")

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
         user example: main.py -p 3 -id 4611686018472661350"""
     parser = argparse.ArgumentParser(prog='main.py', description=f'{descriptionString}', formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--bungie-api-key', '-key', type=str, required=False, help='Your Bungie API key')
-    parser.add_argument('--clan', '-c', type=int, required=False, help='Clan ID as reported on Bungie.net', default='174643')
+    parser.add_argument('--clan', '-c', type=int, required=False, help='Clan ID as reported on Bungie.net')
     parser.add_argument('--member', '-m', type=int, required=False, help='User ID as reported on Bungie.net')
     parser.add_argument('--platform', '-p', type=int, required=False, help='Your platform ID as reported on Bungie.net')
     parser.add_argument('--use-cache', required=False, help='Pull cache data instead of Bungie API', default=False, action='store_true')
@@ -58,21 +58,14 @@ if __name__ == '__main__':
     api = ApiController(api_key=API_KEY, freshPull=freshPull)
 
     # create clan holder
-    if memberId == None:
+    if clan != None:
         cc = ClanCollector(clan, api)
         cc.update(freshPull)
-        clanName = cc.getDisplayName()
     else:
         cc = ClanCollector(clanId=0, api=api)
-        clanName = NULL_CLAN
-
-    # set up results directories
-    LocalController.CreateDirectoriesForClan(clanName)
-    LocalController.ClearResultDirectory(clanName)
-    LocalController.CreateDirectoriesForClan(clanName)
 
     # populate clan members
-    if memberId == None:
+    if clan != None:
         cc.getClanMemberList(freshPull)
     else:
         cc.addMember(platform=platform, membershipId=memberId)
@@ -82,8 +75,10 @@ if __name__ == '__main__':
     pool = ProcessPool()
     # You could also specify the amount of threads. Note that this DRASTICALLY speeds up the process but takes serious computation power.
     # pool = ProcessPool(40)
+
     memberObjects = {}
     # populate PGCRs from clan members
+    clanName = cc.getDisplayName()
     if freshPull:
         for member in tqdm(cc.getClanMembers(), desc="> Fetching clan member PGCRs"):
             member = member['destinyUserInfo']


### PR DESCRIPTION
Refactor to treat single-user pulls as their own clan. All PGCRs and results will be saved to a folder that matches their username. Clean up some references for readability.